### PR TITLE
创建 GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,7 @@ jobs:
             -d '{"reviewers":["WForst-Breeze"]}'
 
       - name: Add "▲ 合并" label on PR merge
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true    
-      - name: Add merge label
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true      
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.SHEEP }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,12 @@ jobs:
             -d '{"reviewers":["WForst-Breeze"]}'
 
       - name: Add "▲ 合并" label on PR merge
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true
-        run: |
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.SHEEP }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
-            -d '{"labels":["▲ 合并"]}'
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true    
+      - name: Add merge label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.SHEEP }}
+          labels: '▲ 合并'
 
       - name: Auto-merge PR with "▲ 合并" label
         if: contains(github.event.pull_request.labels.*.name, '▲ 合并')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ jobs:
   pr_workflow:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Request review from WForst-Breeze on PR creation
         if: github.event.action == 'opened'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,65 @@
+name: auto-PR
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, review_requested, review_request_removed, review_submitted]
+
+jobs:
+  pr_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Request review from WForst-Breeze on PR creation
+        if: github.event.action == 'opened'
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.SHEEP }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -d '{"reviewers":["WForst-Breeze"]}'
+
+      - name: Add "▲ 合并" label on PR merge
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.SHEEP }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d '{"labels":["▲ 合并"]}'
+
+      - name: Auto-merge PR with "▲ 合并" label
+        if: contains(github.event.pull_request.labels.*.name, '▲ 合并')
+        run: |
+          curl -X PUT \
+            -H "Authorization: token ${{ secrets.SHEEP }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/merge
+
+      - name: Add "⇵ 通过" label on approval by WForst-Breeze
+        if: github.event.action == 'submitted' && github.event.review.state == 'approved' && github.event.review.user.login == 'WForst-Breeze'
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.SHEEP }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d '{"labels":["⇵ 通过"]}'
+
+      - name: Close PR with specific labels
+        if: contains(github.event.pull_request.labels.*.name, '× 重新编写') || contains(github.event.pull_request.labels.*.name, '× 无效') || contains(github.event.pull_request.labels.*.name, '× 拒绝')
+        run: |
+          curl -X PATCH \
+            -H "Authorization: token ${{ secrets.SHEEP }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }} \
+            -d '{"state":"closed"}'
+
+      - name: Add "◈ 修正" label on request changes
+        if: github.event.action == 'submitted' && github.event.review.state == 'changes_requested'
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.SHEEP }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d '{"labels":["◈ 修正"]}'


### PR DESCRIPTION
~~是的，我又回来了~~
这次我回去好好研究了一下，**不可能出任何问题了**，如果出问题我就吃一个月夹子（bushi
功能如下，如果需要更改直接和我说就行了：
当一个pr被创建时自动请求“WForst-Breeze”的审查
当一个pr被添加“▲ 合并”标签时，自动合并这个pr
当一个pr被“WForst-Breeze”批准时，自动添加“⇵ 通过”标签
当一个pr被添加了“× 重新编写”“× 无效”“× 拒绝”中的任意一个时，自动close这个pr
当一个pr被任何人request change时，自动添加“◈ 修正”标签